### PR TITLE
Fix rubocop link and config in the ruby style guide

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,7 +1,3 @@
-# Prelude
-
-
-
 # The Ruby Style Guide
 
 This Ruby style guide recommends best practices so that real-world Ruby
@@ -26,8 +22,8 @@ from this guide). In the event of any conflicts, such
 project-specific guides take precedence for that project.
 
 
-[RuboCop][https://github.com/bbatsov/rubocop] is a code analyzer, based on this
-style guide. A rubocop configuration is included in this repo.
+[RuboCop](https://github.com/bbatsov/rubocop) is a code analyzer, based on this
+style guide. You can take a look at the [rails api base rubocop config](https://github.com/rootstrap/rails_api_base/blob/master/.rubocop.yml).
 
 
 ## Table of Contents


### PR DESCRIPTION
Also, I removed the prelude section because there wasn't one (copy/pasted from the ruby style guide, but I removed the content of that section in that time)

As it isn't a rule/guide change, I believe it doesn't need an issue. 

[Preview](https://github.com/rootstrap/guides/tree/fix_rubocop_link/ruby)