### PR TITLE
Add SASS guide

### DIFF
--- a/css.md
+++ b/css.md
@@ -1,3 +1,4 @@
 # The CSS Style Guide
 
 We follow https://cssguidelin.es. In the css naming convention, we are aligned with the Hyphen Delimited convention instead of BEM-like one.
+For SASS, we follow https://sass-guidelin.es/


### PR DESCRIPTION
I noticed that we have a style guide for CSS but we don't for SASS, that is the mainly used extension here I think. I found this one https://sass-guidelin.es/ that seems to be from the same source as https://cssguidelin.es, but perhaps there is another one that is better. I added as reviewers the ones I know they work with SASS, feel free to add anyone that's missing.  