### PR TITLE
Favor extend self on ruby modules

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -2538,7 +2538,7 @@ no parameters.
 
   # good
   module SomeModule
-    module_function
+    extend self
 
     def some_method
       # body omitted
@@ -2550,15 +2550,28 @@ no parameters.
   end
   ```
 
-* <a name="module-function"></a>
-  Favor the use of `module_function` over `extend self` when you want to turn
-  a module's instance methods into class methods.
-<sup>[[link](#module-function)]</sup>
+* <a name="extend-self"></a>
+  Favor the use of `extend self` over `module_function` and `def self.*` when
+  you want to turn a module's instance methods into class methods, unless you
+  need `module_function`.
+<sup>[[link](#extend-self)]</sup>
 
   ```Ruby
   # bad
   module Utilities
-    extend self
+    def self.parse_something(string)
+      # do stuff here
+    end
+
+    def self.other_utility_method(number, string)
+      # do some more stuff
+    end
+    private_class_method other_utility_method
+  end
+
+  # fine if needed
+  module Utilities
+    module_function
 
     def parse_something(string)
       # do stuff here
@@ -2567,15 +2580,18 @@ no parameters.
     def other_utility_method(number, string)
       # do some more stuff
     end
+    private_class_method other_utility_method
   end
 
   # good
   module Utilities
-    module_function
+    extend self
 
     def parse_something(string)
       # do stuff here
     end
+
+    private
 
     def other_utility_method(number, string)
       # do some more stuff


### PR DESCRIPTION
The form `def self.method` is just noisy. It defines a method to be singleton
methdod directly, with nothing special. It has the extra "feature" that we
need to call `private_class_method` on these if we want to make them private.

I'd go straight against it whenever possible.

In the other hand, there are differences between `extend self` and
`module_function` and we can't just ban the use of one or the other, It depends
on what we want to implement.

Let's suppose we want to have a module with two methods:
1. `Utilities.square` (public) A handy method that returns the square for a
given number.
2. `Utilities.multiply` (private) A method internal to this module that we
don't want to expose.

Using `module_function`, will make the instance methods private and make a
copy to the module singleton.

```ruby
module UtilitiesMod
  module_function

  def square(n)
    multiply(n, n)
  end

  def multiply(a, b)
    a * b
  end
end
```

This creates a copy of each method into the singleton, so we can call them
directly:

```ruby
UtilitiesMod.square(3) # => 9
UtilitiesMod.multiply(5, 6) # => 30
```

If we want to make `multiply` private, things become tricky.

We may use `private`, but both `module_function` and `private` set the
visibility, overriding the previous value, so when `private` is called, the
methods that follow will not be "inside" the `module_function`'s scope, thus,
these methods won't be copied:

```ruby
module UtilitiesMod
  module_function

  def square(n)
    multiply(n, n)
  end

  private

  def multiply(a, b)
    a * b
  end
end

UtilitiesMod.square(3) # => Undefined method `multiply`
UtilitiesMod.multiply(5, 6) # => Undefined method `multiply`
```

Another option would be to use `private_class_method`, which is also noisy, and
has to be explicitly called for each method we want to make private (or just
provide it with the list), like so:

```ruby
module UtilitiesMod
  module_function

  def square(n)
    multiply(n, n)
  end

  def multiply(a, b)
    a * b
  end
  private_class_method :multiply
end
```

```ruby
UtilitiesMod.square(3) # => 9
UtilitiesMod.multiply(5, 6) # => Private method `multiply`
```

In other hand `extend self` will make the module extend itself, so all instance
methods will be available via its singleton interface. These methods will
also be available to whoever includes it. For example:

```ruby
module Utilities
  extend self

  def square(n)
    multiply(n, n)
  end

  private

  def multiply(a, b)
    a * b
  end
end
```

This will make the instance methods available as via singleton calls, while
maintainig their visibility:

```ruby
Utilities.square(3) # => 9
Utilities.multiply(5, 6) # => Private method `multiply`
```

As mentioned, the approachs are different and can't be always enforced, but I'd
suggest them on the following scenarios:

When we have a module from which we only want to call its singleton methods,
we could use `extend self`, which provides a clean an easy to understand
result.

We can use `module_function` if our scenario is:
1. We have a module without private methods, that we want to use as singleton.
2. We want to be able to include that module into a class but not allow these
methods +from+ instances of that class.

For example:

```ruby
class MyUtilsMod
  include UtilitiesMod

  def twice(n)
    multiply(n, 2)
  end
end
m = MyUtilsMod.new
m.twice(6) # => 12
m.square(8) # => Private method `square`
m.multiply(10) # => Private method `multiply`
```