### PR TITLE
Add pre-commit installation step to cookiecutter guide

### DIFF
--- a/python/cookiecutter-django.md
+++ b/python/cookiecutter-django.md
@@ -218,6 +218,19 @@ exclude = '.*\/(migrations|settings)\/.*'
     - This command list all the issues found.
     - A useful command could be `$ pipenv run black .` which resolves all the issues. Also, you can run `$ pipenv run black . --diff` to watch the proposed changes.
 
+### [pre-commit](https://pre-commit.com/)
+*NOTE: By default this package is already installed.*
+
+This is optional and is a local configuration. A sample `pre-commit-config` hook already exists in the generated project as default.
+1. `$ pipenv install pre-commit --dev`
+2. `$ pre-commit install` # A git repo is required for pre-commit to install
+
+This will run flake8, black and isort locally before creating a commit. This can avoid having to wait for the CI to fail to remember that we missed some styling issues. You can ignore the pre commit hook by adding `-n` when creating a commit (e.g. `git commit -m 'ignore pre-commit' -n`). 
+
+You can check the `.pre-commit-config.yaml` file for more details.
+
+Note: the first commit after running step 2 will take a while but after that it will be pretty fast.
+
 ### Single-quotes
 > *Here at Rootstrap we prefer to use single-quoted strings over double quotes. For docstrings we use double quotes since the chance of writing a ' is higher in the documentation string of a class or a method.*
 >


### PR DESCRIPTION
Use the already configured `pre-commit` hook.

Running `pre-commit install ` once on your repo will run flake8, black and isort before every commit. If it finds some issues it will fix them and let you add them to your commit. 

This will avoid pushing code with styling issues that will make the CI workflow fail.
<img width="566" alt="example" src="https://user-images.githubusercontent.com/16108743/99136346-12607200-2603-11eb-9d70-69ef81dd064d.png">

