### PR TITLE
Replace TravisCI with GithubActions

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -33,7 +33,7 @@ Having Your Code Reviewed
 - Push commits based on earlier rounds of feedback as isolated commits to the branch. Do not squash until the branch is ready to merge. Reviewers should be able to read individual updates based on their earlier feedback.
 - Seek to understand the reviewer's perspective.
 - One of the reviewers or you can merge once:
-  - Continuous Integration (CircleCi, TravisCi, etc) tells you the test suite is green in the branch.
+  - Continuous Integration (CircleCi, Github Actions, etc) tells you the test suite is green in the branch.
   - Two reviewers approved the PR
 
 Reviewing Code

--- a/open-source/OSS_README_example.md
+++ b/open-source/OSS_README_example.md
@@ -1,6 +1,7 @@
 # [lib_name]
 
-[![Build Status](https://travis-ci.org/rootstrap/[lib_name].svg?branch=master)](https://travis-ci.org/rootstrap/[lib_name])
+
+![Build Status](https://github.com/rootstrap/[lib_name]/workflows/CI/badge.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/[token]/maintainability)](https://codeclimate.com/github/rootstrap/[lib_name]/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/[token]/test_coverage)](https://codeclimate.com/github/rootstrap/[lib_name]/test_coverage)
 

--- a/open-source/README.md
+++ b/open-source/README.md
@@ -12,7 +12,7 @@ This is a guide for publishing and maintaining open source projects, check the G
 - License (default: [MIT](https://opensource.org/licenses/MIT))
 - Code of Conduct (default: [Contributor Covenant](https://www.contributor-covenant.org/))
 - Contributing: We follow the [Rootstrap Contributing Guide](./rootstrap_contributing_guide.md)
-- Continuous Integration (default: [TravisCI](https://travis-ci.org))
+- Continuous Integration (default: [Github Actions](https://github.com/features/actions))
 - Code Quality tools (default: [CodeClimate](https://codeclimate.com))
 - Readme with: Description, Prerequisites/Installation, Usage, Company credits and links to items above (template: [README example](./OSS_README_example.md))
 - Follow [semver](https://semver.org/) for good versioning. Start with version `0.1` and once it has been successfully used in at least one project upgrade to `1.0`. Generate a new git tag when releasing a new version.


### PR DESCRIPTION
TravisCI has been broken for the past years (they were acquired) so it's time to move on to a better CI like Github Actions by default for OSS projects