### PR TITLE
Change black confing and add .env suggestion

### DIFF
--- a/python/cookiecutter-django.md
+++ b/python/cookiecutter-django.md
@@ -159,6 +159,9 @@ For example, let's say you have:
 - A created db named `cookiecutter_starter-db-dev`, and a user `postgres` with password `postgres` 
 - Then the value for `DATABASE_URL` would be: `DATABASE_URL=postgres://postgres:postgres@localhost:5432/cookiecutter_starter-db-dev`
 
+IMPORTANT SUGGESTION:
+- For critical or sensitive information/credentials please use an ENV var in `.env` file and add it also to `.env.example` for consistence.
+
 ### Important Note
 For the next commands, we will assume that you are in the root folder, and you have already entered to the sell with `$ pipenv shell`
 
@@ -213,7 +216,7 @@ extend-ignore = E203, W503
 #  pyproject.toml
 
 [tool.black]
-skip_string_normalization = true
+skip_string_normalization = false
 line-length = 120
 exclude = '.*\/(migrations|settings)\/.*'
 ```


### PR DESCRIPTION
## Change black confing and add .env suggestion


#### Description:

* Change black configuration. `skip_string_normalization = true` was causing all single quotes never were changed to double quotes. It is needed to change it to `skip_string_normalization = false`.
* We need to add a suggestion to .env information for advice on how to handle critical/sensitive data.

---


#### Notes:

* N/A

---