### PR TITLE
Rails: Resource routing && Non existent routes

### DIFF
--- a/ruby/rails.md
+++ b/ruby/rails.md
@@ -199,6 +199,10 @@ it is.
   Don't use `match` to define any routes unless there is need to map multiple request types among `[:get, :post, :patch, :put, :delete]` to a single action using `:via` option.
 <sup>[[link](#no-match-routes)]</sup>
 
+* <a name="non-existing-routes"></a>
+  Don't create routes that are not being used. Use `:only` and `:except` to generate only the routes you actually need.
+<sup>[[link](#non-existing-routes)]</sup>
+
 ## Controllers
 
 * <a name="skinny-controllers"></a>

--- a/ruby/rails.md
+++ b/ruby/rails.md
@@ -84,6 +84,17 @@ it is.
   ```
 
 ## Routing
+* <a name="resource-routing"></a>
+  Prefer `resources` over custom routes.
+<sup>[[link](#resource-routing)]</sup>
+
+  ```Ruby
+  # bad
+  get 'topics/:id', to: 'topics#show'
+
+  # good
+  resources :topics, only: :show
+  ```
 
 * <a name="member-collection-routes"></a>
   When you need to add more actions to a RESTful resource (do you really need


### PR DESCRIPTION
This PR adds:

* Resource routing
Use rails defaults

* Non existent routes
If your application has many RESTful routes, using :only and :except to generate only the routes that you actually need can cut down on memory use and speed up the routing process.