### PR TITLE
change airbnb link with internal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The guidelines exploit Git's advantages with regards to collaborative work, enco
 - [Ruby on Rails](./ruby/rails.md)
 - [Angular 1](https://github.com/johnpapa/angular-styleguide/blob/master/a1)
 - [Angular 2+](https://angular.io/guide/styleguide)
-- [React](https://www.notion.so/rootstrap/6cce30d50e484a10876b2a4667f213af?v=ee0970cdd8d5496d92a245fe9bba25d0)
+- [React](https://www.notion.so/rootstrap/Rootstrap-React-Guidelines-3a7f9ada653e44a185a729b437970a7b?pvs=4)
 - [RSpec](./ruby/rspec/README.md)
 - [Django](./python/cookiecutter-django.md)
 - [Node.Js](./node/README.md)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The guidelines exploit Git's advantages with regards to collaborative work, enco
 - [Ruby on Rails](./ruby/rails.md)
 - [Angular 1](https://github.com/johnpapa/angular-styleguide/blob/master/a1)
 - [Angular 2+](https://angular.io/guide/styleguide)
-- [React](https://github.com/airbnb/javascript/tree/master/react)
+- [React](https://www.notion.so/rootstrap/6cce30d50e484a10876b2a4667f213af?v=ee0970cdd8d5496d92a245fe9bba25d0)
 - [RSpec](./ruby/rspec/README.md)
 - [Django](./python/cookiecutter-django.md)
 - [Node.Js](./node/README.md)


### PR DESCRIPTION
[Discussion Link](https://github.com/rootstrap/tech-guides/issues/NUMBER)

**Description:**
Change AirBNB's deprecated guide with Rootstrap's new ReactJS Wiki